### PR TITLE
Support export failure: unsupported operand type(s) for +: 'NoneType' and 'int'

### DIFF
--- a/src/deform_conv2d_onnx_exporter.py
+++ b/src/deform_conv2d_onnx_exporter.py
@@ -59,7 +59,16 @@ def unsqueeze(g, input, dims):
 
 
 def get_tensor_dim_size(tensor, dim):
-    return sym_help._get_tensor_dim_size(tensor, dim)
+    tensor_dim_size = sym_help._get_tensor_dim_size(tensor, dim)
+    if tensor_dim_size == None and (dim == 2 or dim == 3):
+        import typing
+        from torch import _C
+        
+        x_type = typing.cast(_C.TensorType, tensor.type())
+        x_strides = x_type.strides()
+        
+        tensor_dim_size = x_strides[2] if dim == 3 else x_strides[1] // x_strides[2]
+    return tensor_dim_size
 
 
 def tensor(g, value, dtype):


### PR DESCRIPTION
```
[old]
def get_tensor_dim_size(tensor, dim):	
    return sym_help._get_tensor_dim_size(tensor, dim)

[new]
def get_tensor_dim_size(tensor, dim):
    tensor_dim_size = sym_help._get_tensor_dim_size(tensor, dim)
    if tensor_dim_size == None and (dim == 2 or dim == 3):
        import typing
        from torch import _C
        
        x_type = typing.cast(_C.TensorType, tensor.type())
        x_strides = x_type.strides()
        
        tensor_dim_size = x_strides[2] if dim == 3 else x_strides[1] // x_strides[2]
    return tensor_dim_size
```